### PR TITLE
Add support for pipes

### DIFF
--- a/src/cas.rs
+++ b/src/cas.rs
@@ -54,7 +54,7 @@ pub fn load(hexhash: &str, paops: &mut ParseOps) -> Result<Vec<u8>, &'static str
     match file_in.read_to_end(&mut blob) {
         Ok(bytes) => {
             if paops.verbose {
-                println!("cas::load(): {} bytes from {}", bytes, path.display());
+                eprintln!("cas::load(): {} bytes from {}", bytes, path.display());
             }
         }
         Err(e) => {
@@ -85,7 +85,7 @@ pub fn save(blob: Vec<u8>, paops: &mut ParseOps) -> Result<String, &'static str>
     // check if it exists
     if path.is_file() {
         if paops.verbose {
-            println!("cas:save(): {} already exists. Exiting.", path.display());
+            eprintln!("cas:save(): {} already exists. Exiting.", path.display());
         }
         return Ok(hexhash);
     }
@@ -103,7 +103,7 @@ pub fn save(blob: Vec<u8>, paops: &mut ParseOps) -> Result<String, &'static str>
     match file_out.write(&blob) {
         Ok(bytes) => {
             if paops.verbose {
-                println!("cas:save(): {} bytes to {}", bytes, path.display());
+                eprintln!("cas:save(): {} bytes to {}", bytes, path.display());
             }
         }
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ where
 
     // print some of the processing parameters if verbose
     if paops.verbose {
-        println!(
+        eprintln!(
             "LEFT_SEP='{}' RIGHT_SEP='{}' casdir = '{}'",
             paops.left_sep,
             paops.right_sep,
@@ -385,7 +385,7 @@ where
 
     for (path_in, path_out) in files {
         if paops.verbose {
-            println!("Reading {}", path_in);
+            eprintln!("Reading {}", path_in);
         }
 
         // open input file
@@ -409,7 +409,7 @@ where
 
         // transform it
         if paops.verbose {
-            println!("Transforming {}", path_in);
+            eprintln!("Transforming {}", path_in);
         }
         let tree_out = match etree::transform(&tree_in, &mut paops) {
             Ok(tree) => tree,
@@ -421,7 +421,7 @@ where
 
         // write it out
         if paops.verbose {
-            println!("Writing {}", path_out);
+            eprintln!("Writing {}", path_out);
         }
 
         // open output file

--- a/tests/cli/misc.rs
+++ b/tests/cli/misc.rs
@@ -48,21 +48,21 @@ fn verbosity() {
         .arg(&ept.path)
         .assert()
         .success()
-        .stdout(predicate::str::contains("LEFT_SEP").not());
+        .stderr(predicate::str::contains("LEFT_SEP").not());
     Command::cargo_bin("enprot")
         .unwrap()
         .arg("-v")
         .arg(&ept.path)
         .assert()
         .success()
-        .stdout(predicate::str::contains("LEFT_SEP"));
+        .stderr(predicate::str::contains("LEFT_SEP"));
     Command::cargo_bin("enprot")
         .unwrap()
         .arg("--verbose")
         .arg(&ept.path)
         .assert()
         .success()
-        .stdout(predicate::str::contains("LEFT_SEP"));
+        .stderr(predicate::str::contains("LEFT_SEP"));
     // file should be unchanged
     assert_eq!(
         &fs::read_to_string(&ept.source).unwrap(),

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,4 +1,5 @@
 mod encrypt_decrypt;
 mod encrypt_store;
 mod misc;
+mod pipe;
 mod store_fetch;

--- a/tests/cli/pipe.rs
+++ b/tests/cli/pipe.rs
@@ -1,0 +1,118 @@
+extern crate assert_cmd;
+extern crate predicates;
+extern crate tempfile;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::fs;
+use std::process::Command;
+
+use Fixture;
+
+#[test]
+fn pipe_test_passthrough_default() {
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .with_stdin()
+        .buffer(fs::read_to_string("sample/test.ept").unwrap())
+        .assert()
+        .success()
+        .stdout(fs::read_to_string("test-data/test-encrypt-agent007.ept").unwrap());
+}
+
+#[test]
+fn pipe_test_passthrough() {
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .arg("-")
+        .with_stdin()
+        .buffer(fs::read_to_string("sample/test.ept").unwrap())
+        .assert()
+        .success()
+        .stdout(fs::read_to_string("test-data/test-encrypt-agent007.ept").unwrap());
+}
+
+#[test]
+fn pipe_test_1() {
+    let out = Fixture::blank("out.ept");
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .arg("-")
+        .arg("-o")
+        .arg(&out.path)
+        .with_stdin()
+        .buffer(fs::read_to_string("sample/test.ept").unwrap())
+        .assert()
+        .success()
+        .stdout("");
+    assert_eq!(
+        &fs::read_to_string(&out.path).unwrap(),
+        &fs::read_to_string("test-data/test-encrypt-agent007.ept").unwrap(),
+    );
+}
+
+#[test]
+fn pipe_test_2() {
+    let ept = Fixture::copy("sample/test.ept");
+    let out = Fixture::blank("out.ept");
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .success()
+        .stdout(fs::read_to_string("test-data/test-encrypt-agent007.ept").unwrap());
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&ept.source).unwrap()
+    );
+}
+
+#[test]
+fn pipe_test_3() {
+    let ept = Fixture::copy("sample/simple.ept");
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .arg("-")
+        .arg(&ept.path)
+        .with_stdin()
+        .buffer(fs::read_to_string("sample/test.ept").unwrap())
+        .assert()
+        .success()
+        .stdout(fs::read_to_string("test-data/test-encrypt-agent007.ept").unwrap());
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string("test-data/simple-encrypt-agent007.ept").unwrap()
+    );
+}


### PR DESCRIPTION
Reading from stdin is now the default if no input is supplied.

`enprot`
`enprot -`
* input: stdin
* output: stdout

`enprot - -o file.ept`
* input: stdin
* output: file.ept

`enprot file.ept -o -`
* input: file.ept
* output: stdout

`enprot - file.ept`
* input: stdin, output: stdout
* input: file.ept, output: file.ept
