### PR TITLE
Add PBKDF caching

### DIFF
--- a/src/etree.rs
+++ b/src/etree.rs
@@ -72,7 +72,7 @@ pub struct ParseOps {
     pub verbose: bool,                             // verbose output to stdout
     pub rng: Option<botan::RandomNumberGenerator>, // RNG to use
     pub pbkdf: PBKDFOptions,                       // the PBKDF options
-    pub pbkdf_cache: PBKDFCache,                   // the PBKDF cache
+    pub pbkdf_cache: Option<PBKDFCache>,           // the PBKDF cache
     level: isize,                                  // current recursion level
 }
 
@@ -92,7 +92,7 @@ impl ParseOps {
             verbose: false,
             rng: Some(botan::RandomNumberGenerator::new().unwrap()),
             pbkdf: PBKDFOptions::new(),
-            pbkdf_cache: Vec::new(),
+            pbkdf_cache: Some(Vec::new()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,11 @@ where
                 .help("Set the hash algorithm to use for PBKDF2"),
         )
         .arg(
+            Arg::with_name("pbkdf-disable-cache")
+                .long("pbkdf-disable-cache")
+                .help("Disable the PBKDF cache mechanism"),
+        )
+        .arg(
             Arg::with_name("decrypt")
                 .short("d")
                 .long("decrypt")
@@ -358,6 +363,9 @@ where
         paops.pbkdf.pbkdf2_hash = matches.value_of("pbkdf2-hash").map(|v| v.to_string());
     } else if paops.pbkdf.alg == "pbkdf2" {
         paops.pbkdf.pbkdf2_hash = Some(consts::DEFAULT_PBKDF2_HASH_ALG.to_string());
+    }
+    if matches.occurrences_of("pbkdf-disable-cache") != 0 {
+        paops.pbkdf_cache = None;
     }
 
     // print some of the processing parameters if verbose

--- a/src/prot.rs
+++ b/src/prot.rs
@@ -56,7 +56,7 @@ pub fn encrypt(
     password: &str,
     rng: &Option<botan::RandomNumberGenerator>,
     opts: &etree::PBKDFOptions,
-    cache: &mut PBKDFCache,
+    cache: &mut Option<PBKDFCache>,
 ) -> Result<(Vec<u8>, Option<String>), &'static str> {
     let (key, pbkdf) = derive_key(password, consts::AES256_KEY_LENGTH, rng, opts, cache)?;
     let enc = botan::Cipher::new("AES-256/SIV", botan::CipherDirection::Encrypt)
@@ -72,7 +72,7 @@ pub fn decrypt(
     ct: Vec<u8>,
     password: &str,
     pbkdf: &Option<String>,
-    cache: &mut PBKDFCache,
+    cache: &mut Option<PBKDFCache>,
 ) -> Result<Vec<u8>, &'static str> {
     let key: Vec<u8>;
     if let Some(pbkdf) = pbkdf {

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,5 +1,6 @@
 mod encrypt_decrypt;
 mod encrypt_store;
 mod misc;
+mod pbkdf;
 mod pipe;
 mod store_fetch;

--- a/tests/cli/pbkdf.rs
+++ b/tests/cli/pbkdf.rs
@@ -1,0 +1,137 @@
+extern crate assert_cmd;
+extern crate predicates;
+extern crate tempfile;
+
+use assert_cmd::prelude::*;
+use std::fs;
+use std::process::Command;
+use std::time::Instant;
+use tempfile::tempdir;
+
+use Fixture;
+
+#[test]
+fn pbkdf_cache() {
+    let casdir = tempdir().unwrap();
+    let ept = Fixture::copy("sample/test.ept");
+    let out = Fixture::blank("out.ept");
+    const MSEC: &str = "10";
+    const SAMPLE_COUNT: u32 = 3;
+    let (encms_cache, encms_nocache, decms_cache, decms_nocache): (u32, u32, u32, u32);
+    let mut elapsed_ms: u32 = 0;
+
+    // with pbkdf cache
+    for _ in 0..SAMPLE_COUNT {
+        let now = Instant::now();
+        Command::cargo_bin("enprot")
+            .unwrap()
+            .arg("-c")
+            .arg(casdir.path())
+            .arg("-e")
+            .arg("Agent_007")
+            .arg("--pbkdf")
+            .arg("argon2")
+            .arg("--pbkdf-msec")
+            .arg(MSEC)
+            .arg("-k")
+            .arg("Agent_007=password")
+            .arg(&ept.path)
+            .arg("-o")
+            .arg(&out.path)
+            .assert()
+            .success();
+        elapsed_ms += now.elapsed().as_millis() as u32;
+    }
+    encms_cache = (elapsed_ms as f32 / SAMPLE_COUNT as f32) as u32;
+    // check output
+    assert!(&fs::read_to_string(&out.path).unwrap().contains("$argon2$"));
+    assert_ne!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&out.path).unwrap(),
+    );
+    elapsed_ms = 0;
+    for _ in 0..SAMPLE_COUNT {
+        let dec = Fixture::blank("dec.ept");
+        let now = Instant::now();
+        Command::cargo_bin("enprot")
+            .unwrap()
+            .arg("-c")
+            .arg(casdir.path())
+            .arg("-d")
+            .arg("Agent_007")
+            .arg("-k")
+            .arg("Agent_007=password")
+            .arg(&out.path)
+            .arg("-o")
+            .arg(&dec.path)
+            .assert()
+            .success();
+        elapsed_ms += now.elapsed().as_millis() as u32;
+        assert_eq!(
+            &fs::read_to_string(&ept.path).unwrap(),
+            &fs::read_to_string(&dec.path).unwrap()
+        );
+    }
+    decms_cache = (elapsed_ms as f32 / SAMPLE_COUNT as f32) as u32;
+
+    // without pbkdf cache
+    elapsed_ms = 0;
+    for _ in 0..SAMPLE_COUNT {
+        let now = Instant::now();
+        Command::cargo_bin("enprot")
+            .unwrap()
+            .arg("-c")
+            .arg(casdir.path())
+            .arg("-e")
+            .arg("Agent_007")
+            .arg("--pbkdf")
+            .arg("argon2")
+            .arg("--pbkdf-msec")
+            .arg(MSEC)
+            .arg("--pbkdf-disable-cache")
+            .arg("-k")
+            .arg("Agent_007=password")
+            .arg(&ept.path)
+            .arg("-o")
+            .arg(&out.path)
+            .assert()
+            .success();
+        elapsed_ms += now.elapsed().as_millis() as u32;
+    }
+    encms_nocache = (elapsed_ms as f32 / SAMPLE_COUNT as f32) as u32;
+    // check output
+    assert!(&fs::read_to_string(&out.path).unwrap().contains("$argon2$"));
+    assert_ne!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&out.path).unwrap(),
+    );
+    elapsed_ms = 0;
+    for _ in 0..SAMPLE_COUNT {
+        let dec = Fixture::blank("dec.ept");
+        let now = Instant::now();
+        Command::cargo_bin("enprot")
+            .unwrap()
+            .arg("-c")
+            .arg(casdir.path())
+            .arg("-d")
+            .arg("Agent_007")
+            .arg("-k")
+            .arg("Agent_007=password")
+            .arg("--pbkdf-disable-cache")
+            .arg(&out.path)
+            .arg("-o")
+            .arg(&dec.path)
+            .assert()
+            .success();
+        elapsed_ms += now.elapsed().as_millis() as u32;
+        assert_eq!(
+            &fs::read_to_string(&ept.path).unwrap(),
+            &fs::read_to_string(&dec.path).unwrap()
+        );
+    }
+    decms_nocache = (elapsed_ms as f32 / SAMPLE_COUNT as f32) as u32;
+
+    // using cache should be consistently quicker
+    assert!(encms_cache < encms_nocache);
+    assert!(decms_cache < decms_nocache);
+}

--- a/tests/cli/pipe.rs
+++ b/tests/cli/pipe.rs
@@ -3,7 +3,6 @@ extern crate predicates;
 extern crate tempfile;
 
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
 use std::fs;
 use std::process::Command;
 
@@ -72,7 +71,6 @@ fn pipe_test_1() {
 #[test]
 fn pipe_test_2() {
     let ept = Fixture::copy("sample/test.ept");
-    let out = Fixture::blank("out.ept");
     Command::cargo_bin("enprot")
         .unwrap()
         .arg("-e")


### PR DESCRIPTION
master:
```
$ time target/debug/enprot -e Agent_007 -k Agent_007=password sample/test.ept -o -
[...]
1.15 real
```

this branch:
```
$ time target/debug/enprot -e Agent_007 -k Agent_007=password sample/test.ept -o -
[...]
0.63 real
```

Of course this is just an example with 2 entries for Agent_007, the point is that it scales better.