### PR TITLE
Add AES-GCM support and crypto policy framework

### DIFF
--- a/src/cas.rs
+++ b/src/cas.rs
@@ -29,7 +29,7 @@ use etree::ParseOps;
 use std::fs::File;
 use std::io::prelude::*;
 
-use utils;
+use crypto;
 
 pub fn load(hexhash: &str, paops: &mut ParseOps) -> Result<Vec<u8>, &'static str> {
     // check that it is valid
@@ -64,7 +64,7 @@ pub fn load(hexhash: &str, paops: &mut ParseOps) -> Result<Vec<u8>, &'static str
     }
 
     // verify hash just because
-    let verify = utils::hexdigest("SHA-3(256)", &blob)?;
+    let verify = crypto::hexdigest("SHA-3(256)", &blob, &paops.policy)?;
 
     if hexhash != verify {
         eprintln!(
@@ -78,7 +78,7 @@ pub fn load(hexhash: &str, paops: &mut ParseOps) -> Result<Vec<u8>, &'static str
 }
 
 pub fn save(blob: Vec<u8>, paops: &mut ParseOps) -> Result<String, &'static str> {
-    let hexhash = utils::hexdigest("SHA-3(256)", &blob)?;
+    let hexhash = crypto::hexdigest("SHA-3(256)", &blob, &paops.policy)?;
     let mut path = paops.casdir.clone();
     path.push(&hexhash);
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -21,11 +21,23 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+extern crate phf;
+
+use self::phf::phf_map;
+
 // pbkdf
 pub const DEFAULT_PBKDF_ALG: &str = "argon2";
 pub const DEFAULT_PBKDF_SALT_LEN: usize = 16;
 pub const DEFAULT_PBKDF_MSEC: u32 = 100;
 pub const DEFAULT_PBKDF2_HASH_ALG: &str = "sha256";
+
+// cipher
+pub const DEFAULT_CIPHER_ALG: &str = "aes-256-siv";
+pub const VALID_CIPHER_ALGS: &[&str] = &["aes-256-siv", "aes-256-gcm"];
+pub static BOTAN_CIPHER_ALG_MAP: phf::Map<&'static str, &'static str> = phf_map! {
+    "aes-256-siv" => "AES-256/SIV",
+    "aes-256-gcm" => "AES-256/GCM",
+};
 
 // parsing separators
 pub const DEFAULT_LEFT_SEP: &str = "// <(";
@@ -34,8 +46,6 @@ pub const DEFAULT_RIGHT_SEP: &str = ")>";
 // valid value lists
 pub const VALID_PBKDF_ALGS: &[&str] = &["argon2", "scrypt", "pbkdf2", "legacy"];
 pub const VALID_PBKDF2_HASH_ALGS: &[&str] = &["sha256", "sha512"];
-
-pub const AES256_KEY_LENGTH: usize = 64;
 
 // policies
 pub const VALID_POLICIES: &[&str] = &["none"];

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -36,3 +36,7 @@ pub const VALID_PBKDF_ALGS: &[&str] = &["argon2", "scrypt", "pbkdf2", "legacy"];
 pub const VALID_PBKDF2_HASH_ALGS: &[&str] = &["sha256", "sha512"];
 
 pub const AES256_KEY_LENGTH: usize = 64;
+
+// policies
+pub const VALID_POLICIES: &[&str] = &["none"];
+pub const DEFAULT_POLICY: &str = "none";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -24,6 +24,7 @@
 extern crate phf;
 
 use self::phf::phf_map;
+use self::phf::phf_set;
 
 // pbkdf
 pub const DEFAULT_PBKDF_ALG: &str = "argon2";
@@ -48,5 +49,19 @@ pub const VALID_PBKDF_ALGS: &[&str] = &["argon2", "scrypt", "pbkdf2", "legacy"];
 pub const VALID_PBKDF2_HASH_ALGS: &[&str] = &["sha256", "sha512"];
 
 // policies
-pub const VALID_POLICIES: &[&str] = &["none"];
+pub const VALID_POLICIES: &[&str] = &["none", "nist"];
 pub const DEFAULT_POLICY: &str = "none";
+
+// NIST
+pub static NIST_APPROVED_PBKDFS: phf::Set<&'static str> = phf_set! {
+    "PBKDF2(SHA-256)",
+    "PBKDF2(SHA-512)",
+};
+pub static NIST_APPROVED_CIPHERS: phf::Set<&'static str> = phf_set! {
+    "AES-256/GCM",
+};
+pub static NIST_APPROVED_HASHES: phf::Set<&'static str> = phf_set! {
+    "SHA-3(256)",
+    "SHA-3(512)",
+};
+pub static NIST_PBKDF_MIN_SALT_LEN: usize = 16;

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2019 [Ribose Inc](https://www.ribose.com).
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+extern crate botan;
+extern crate phf;
+
+use std::collections::HashMap;
+
+pub trait CryptoPolicy {
+    fn check_hash(&self, _alg: &str) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn check_pbkdf(
+        &self,
+        _alg: &str,
+        _key_len: usize,
+        _password: &str,
+        _salt: &[u8],
+        _params: &HashMap<String, usize>,
+    ) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn check_cipher(
+        &self,
+        _alg: &str,
+        _key: &[u8],
+        _iv: &[u8],
+        _ad: &[u8],
+    ) -> Result<(), &'static str> {
+        Ok(())
+    }
+}
+
+pub struct CryptoPolicyNone {}
+
+impl CryptoPolicy for CryptoPolicyNone {}
+
+pub fn digest(
+    alg: &str,
+    data: &[u8],
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<Vec<u8>, &'static str> {
+    policy.check_hash(alg)?;
+    let hash = botan::HashFunction::new(alg).map_err(|_| "Botan error")?;
+    hash.update(data).map_err(|_| "Botan error")?;
+    hash.finish().map_err(|_| "Botan error")
+}
+
+pub fn hexdigest(
+    alg: &str,
+    data: &[u8],
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<String, &'static str> {
+    Ok(hex::encode(digest(alg, data, policy)?))
+}
+
+fn symmetric_cipher(
+    alg: &str,
+    key: &[u8],
+    iv: &[u8],
+    ad: &[u8],
+    data: &[u8],
+    direction: botan::CipherDirection,
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<Vec<u8>, &'static str> {
+    policy.check_cipher(alg, key, iv, ad)?;
+    let cipher = botan::Cipher::new(alg, direction).map_err(|_| "Botan error")?;
+    cipher.set_key(key).map_err(|_| "Botan error")?;
+    cipher.set_associated_data(ad).map_err(|_| "Botan error")?;
+    cipher.process(iv, data).map_err(|_| "Botan error")
+}
+
+pub fn encrypt(
+    alg: &str,
+    key: &[u8],
+    iv: &[u8],
+    ad: &[u8],
+    pt: &[u8],
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<Vec<u8>, &'static str> {
+    symmetric_cipher(
+        alg,
+        key,
+        iv,
+        ad,
+        pt,
+        botan::CipherDirection::Encrypt,
+        policy,
+    )
+}
+
+pub fn decrypt(
+    alg: &str,
+    key: &[u8],
+    iv: &[u8],
+    ad: &[u8],
+    ct: &[u8],
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<Vec<u8>, &'static str> {
+    symmetric_cipher(
+        alg,
+        key,
+        iv,
+        ad,
+        ct,
+        botan::CipherDirection::Decrypt,
+        policy,
+    )
+}
+
+pub fn derive_key_from_password(
+    alg: &str,
+    param_order: &[&[&str; 3]; 2],
+    key_len: usize,
+    password: &str,
+    salt: &[u8],
+    mut params_map: HashMap<String, usize>,
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<Vec<u8>, &'static str> {
+    policy.check_pbkdf(alg, key_len, password, salt, &params_map)?;
+    let mut params: [usize; 3] = [0, 0, 0];
+    for (i, param) in param_order[1].iter().enumerate() {
+        if param.is_empty() {
+            continue;
+        }
+        params[i] = params_map.remove(*param).ok_or("Missing PBKDF parameter")?;
+    }
+    if !params_map.is_empty() {
+        return Err("Extraneous PBKDF parameters");
+    }
+    let key = botan::derive_key_from_password(
+        alg, key_len, password, salt, params[0], params[1], params[2],
+    )
+    .map_err(|_| "Botan error")?;
+    Ok(key)
+}
+
+pub fn derive_key_from_password_timed(
+    alg: &str,
+    param_order: &[&[&str; 3]; 2],
+    key_len: usize,
+    password: &str,
+    salt: &[u8],
+    msec: u32,
+    policy: &Box<dyn CryptoPolicy>,
+) -> Result<(Vec<u8>, HashMap<String, usize>), &'static str> {
+    let (key, param1, param2, param3) =
+        botan::derive_key_from_password_timed(alg, key_len, password, &salt, msec)
+            .map_err(|_| "Botan error")?;
+    let params = [param1, param2, param3];
+    let mut params_map = HashMap::new();
+    for (i, param) in param_order[0].iter().filter(|v| !v.is_empty()).enumerate() {
+        params_map.insert(param.to_string(), params[i]);
+    }
+    policy.check_pbkdf(alg, key_len, password, salt, &params_map)?;
+    Ok((key, params_map))
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -24,7 +24,7 @@
 extern crate botan;
 extern crate phf;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub trait CryptoPolicy {
     fn check_hash(&self, _alg: &str) -> Result<(), &'static str> {
@@ -37,7 +37,7 @@ pub trait CryptoPolicy {
         _key_len: usize,
         _password: &str,
         _salt: &[u8],
-        _params: &HashMap<String, usize>,
+        _params: &BTreeMap<String, usize>,
     ) -> Result<(), &'static str> {
         Ok(())
     }
@@ -136,7 +136,7 @@ pub fn derive_key_from_password(
     key_len: usize,
     password: &str,
     salt: &[u8],
-    mut params_map: HashMap<String, usize>,
+    mut params_map: BTreeMap<String, usize>,
     policy: &Box<dyn CryptoPolicy>,
 ) -> Result<Vec<u8>, &'static str> {
     policy.check_pbkdf(alg, key_len, password, salt, &params_map)?;
@@ -165,12 +165,12 @@ pub fn derive_key_from_password_timed(
     salt: &[u8],
     msec: u32,
     policy: &Box<dyn CryptoPolicy>,
-) -> Result<(Vec<u8>, HashMap<String, usize>), &'static str> {
+) -> Result<(Vec<u8>, BTreeMap<String, usize>), &'static str> {
     let (key, param1, param2, param3) =
         botan::derive_key_from_password_timed(alg, key_len, password, &salt, msec)
             .map_err(|_| "Botan error")?;
     let params = [param1, param2, param3];
-    let mut params_map = HashMap::new();
+    let mut params_map = BTreeMap::new();
     for (i, param) in param_order[0].iter().filter(|v| !v.is_empty()).enumerate() {
         params_map.insert(param.to_string(), params[i]);
     }

--- a/src/etree.rs
+++ b/src/etree.rs
@@ -498,45 +498,20 @@ pub fn tree_write<W: Write>(outw: &mut W, text: &TextTree, paops: &mut ParseOps)
                 txt,
                 ref pbkdf,
             } => {
+                write!(outw, "{} ENCRYPTED {}", paops.left_sep, keyw).unwrap();
                 if let TextNode::Stored { keyw: _, ref cas } = txt[0] {
-                    if *pbkdf == None {
-                        writeln!(
-                            outw,
-                            "{} ENCRYPTED {} {} {}",
-                            paops.left_sep, keyw, cas, paops.right_sep
-                        )
-                        .unwrap();
-                    } else {
-                        writeln!(
-                            outw,
-                            "{} ENCRYPTED {} {} pbkdf:{} {}",
-                            paops.left_sep,
-                            keyw,
-                            cas,
-                            &pbkdf.clone().unwrap(),
-                            paops.right_sep
-                        )
-                        .unwrap();
+                    // Encrypted+Stored
+                    write!(outw, " {}", cas).unwrap();
+                    if *pbkdf != None {
+                        write!(outw, " pbkdf:{}", &pbkdf.clone().unwrap()).unwrap();
                     }
+                    writeln!(outw, " {}", paops.right_sep).unwrap();
                 } else {
-                    if *pbkdf == None {
-                        writeln!(
-                            outw,
-                            "{} ENCRYPTED {} {}",
-                            paops.left_sep, keyw, paops.right_sep
-                        )
-                        .unwrap();
-                    } else {
-                        writeln!(
-                            outw,
-                            "{} ENCRYPTED {} pbkdf:{} {}",
-                            paops.left_sep,
-                            keyw,
-                            &pbkdf.clone().unwrap(),
-                            paops.right_sep
-                        )
-                        .unwrap();
+                    // Encrypted
+                    if *pbkdf != None {
+                        write!(outw, " pbkdf:{}", &pbkdf.clone().unwrap()).unwrap();
                     }
+                    writeln!(outw, " {}", paops.right_sep).unwrap();
                     paops.level += 1;
                     tree_write(outw, txt, paops);
                     paops.level -= 1;

--- a/src/etree.rs
+++ b/src/etree.rs
@@ -23,6 +23,7 @@
 
 extern crate botan;
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::prelude::*;
@@ -38,12 +39,12 @@ use prot;
 use utils;
 
 pub struct PBKDFOptions {
-    pub alg: String,                            // algorithm name
-    pub pbkdf2_hash: Option<String>,            // hash alg to use when alg is PBKDF2
-    pub saltlen: usize,                         // desired salt length
-    pub salt: Option<Vec<u8>>,                  // salt (randomly generated if None)
-    pub msec: Option<u32>,                      // desired millis count to determine KDF params
-    pub params: Option<HashMap<String, usize>>, // KDF-specific params (if provided)
+    pub alg: String,                             // algorithm name
+    pub pbkdf2_hash: Option<String>,             // hash alg to use when alg is PBKDF2
+    pub saltlen: usize,                          // desired salt length
+    pub salt: Option<Vec<u8>>,                   // salt (randomly generated if None)
+    pub msec: Option<u32>,                       // desired millis count to determine KDF params
+    pub params: Option<BTreeMap<String, usize>>, // KDF-specific params (if provided)
 }
 
 impl PBKDFOptions {
@@ -194,8 +195,8 @@ fn parse_begin(
 }
 
 // parse trailing extended fields, such as pbkdf:
-fn parse_encrypted_extfields(cmd: &[&str]) -> Result<HashMap<String, String>, &'static str> {
-    let mut extfields: HashMap<String, String> = HashMap::new();
+fn parse_encrypted_extfields(cmd: &[&str]) -> Result<BTreeMap<String, String>, &'static str> {
+    let mut extfields: BTreeMap<String, String> = BTreeMap::new();
     for field in cmd.iter().rev() {
         if field.find(':') == None {
             // extended fields always come at the end

--- a/src/etree.rs
+++ b/src/etree.rs
@@ -60,6 +60,20 @@ impl PBKDFOptions {
     }
 }
 
+pub struct CipherOptions {
+    pub alg: String,
+    pub iv: Option<Vec<u8>>,
+}
+
+impl CipherOptions {
+    pub fn new() -> CipherOptions {
+        CipherOptions {
+            alg: consts::DEFAULT_CIPHER_ALG.to_string(),
+            iv: None,
+        }
+    }
+}
+
 // parse operations
 
 pub struct ParseOps {
@@ -77,6 +91,7 @@ pub struct ParseOps {
     pub pbkdf: PBKDFOptions,                       // the PBKDF options
     pub pbkdf_cache: Option<PBKDFCache>,           // the PBKDF cache
     pub policy: Box<dyn CryptoPolicy>,             // the crypto alg policy
+    pub cipheropts: CipherOptions,                 // cipher options
     level: isize,                                  // current recursion level
 }
 
@@ -98,6 +113,7 @@ impl ParseOps {
             pbkdf: PBKDFOptions::new(),
             pbkdf_cache: Some(Vec::new()),
             policy: Box::new(CryptoPolicyNone {}),
+            cipheropts: CipherOptions::new(),
         }
     }
 }
@@ -594,6 +610,7 @@ pub fn transform(text_in: &TextTree, mut paops: &mut ParseOps) -> Result<TextTre
                         &pass,
                         &paops.rng,
                         &paops.pbkdf,
+                        &paops.cipheropts,
                         &mut paops.pbkdf_cache,
                         &paops.policy,
                     )?;
@@ -673,6 +690,7 @@ pub fn transform(text_in: &TextTree, mut paops: &mut ParseOps) -> Result<TextTre
                         ct,
                         &pass,
                         &extfields.get("pbkdf"),
+                        &extfields.get("cipher"),
                         &mut paops.pbkdf_cache,
                         &paops.policy,
                     ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,7 @@ where
     //policy
     paops.policy = match matches.value_of("policy").unwrap() {
         "none" => Box::new(crypto::CryptoPolicyNone {}),
+        "nist" => Box::new(crypto::CryptoPolicyNIST::new()),
         _ => {
             std::process::exit(1);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod pbkdf;
 mod prot;
 pub mod utils;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
@@ -347,7 +347,7 @@ where
     );
     if let Some(val) = matches.value_of("pbkdf-params") {
         paops.pbkdf.msec = None;
-        let mut params: HashMap<String, usize> = HashMap::new();
+        let mut params: BTreeMap<String, usize> = BTreeMap::new();
         params.extend(val.split(",").map(|val| {
             let parts = val.splitn(2, '=').collect::<Vec<&str>>();
             (parts[0].to_string(), parts[1].parse::<usize>().unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,23 @@ where
                 .help("Disable the PBKDF cache mechanism"),
         )
         .arg(
+            Arg::with_name("cipher")
+                .long("cipher")
+                .takes_value(true)
+                .value_name("ALG")
+                .default_value(consts::DEFAULT_CIPHER_ALG)
+                .possible_values(consts::VALID_CIPHER_ALGS)
+                .help("Set the cipher algorithm to use when encrypting"),
+        )
+        .arg(
+            Arg::with_name("cipher-iv")
+                .long("cipher-iv")
+                .takes_value(true)
+                .value_name("ALG")
+                .hidden(true)
+                .help("Advanced option for testing, do not use"),
+        )
+        .arg(
             Arg::with_name("decrypt")
                 .short("d")
                 .long("decrypt")
@@ -376,6 +393,11 @@ where
     }
     if matches.occurrences_of("pbkdf-disable-cache") != 0 {
         paops.pbkdf_cache = None;
+    }
+    // cipher
+    paops.cipheropts.alg = matches.value_of("cipher").unwrap().to_string();
+    if let Some(iv) = matches.value_of("cipher-iv") {
+        paops.cipheropts.iv = Some(hex::decode(iv).unwrap());
     }
     //policy
     paops.policy = match matches.value_of("policy").unwrap() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 
 mod cas;
 mod consts;
+pub mod crypto;
 mod etree;
 mod pbkdf;
 mod prot;
@@ -156,6 +157,15 @@ where
                 .multiple(true)
                 .number_of_values(1)
                 .help("Encrypt and store WORD segments"),
+        )
+        .arg(
+            Arg::with_name("policy")
+                .long("policy")
+                .takes_value(true)
+                .value_name("POLICY")
+                .default_value(consts::DEFAULT_POLICY)
+                .possible_values(consts::VALID_POLICIES)
+                .help("Set the policy to restrict cryptographic algorithms"),
         )
         .arg(
             Arg::with_name("pbkdf")
@@ -367,6 +377,13 @@ where
     if matches.occurrences_of("pbkdf-disable-cache") != 0 {
         paops.pbkdf_cache = None;
     }
+    //policy
+    paops.policy = match matches.value_of("policy").unwrap() {
+        "none" => Box::new(crypto::CryptoPolicyNone {}),
+        _ => {
+            std::process::exit(1);
+        }
+    };
 
     // print some of the processing parameters if verbose
     if paops.verbose {

--- a/src/pbkdf.rs
+++ b/src/pbkdf.rs
@@ -81,7 +81,9 @@ fn pbkdf_legacy(
     policy: &Box<dyn CryptoPolicy>,
 ) -> Result<Vec<u8>, &'static str> {
     policy.check_pbkdf("SHA-3(512)", key_len, password, &[], &BTreeMap::new())?;
-    crypto::digest("SHA-3(512)", password.as_bytes(), policy)
+    let mut result = crypto::digest("SHA-3(512)", password.as_bytes(), policy)?;
+    result.truncate(key_len);
+    Ok(result)
 }
 
 fn pbkdf_timed(

--- a/src/pbkdf.rs
+++ b/src/pbkdf.rs
@@ -24,7 +24,7 @@
 extern crate phf;
 
 use self::phf::phf_map;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crypto;
 use crypto::CryptoPolicy;
@@ -49,7 +49,7 @@ pub struct PBKDFCacheEntry {
     pub msec: u32,
     pub salt: Vec<u8>,
     pub key: Vec<u8>,
-    pub params: HashMap<String, usize>,
+    pub params: BTreeMap<String, usize>,
 }
 pub type PBKDFCache = Vec<PBKDFCacheEntry>;
 
@@ -80,7 +80,7 @@ fn pbkdf_legacy(
     key_len: usize,
     policy: &Box<dyn CryptoPolicy>,
 ) -> Result<Vec<u8>, &'static str> {
-    policy.check_pbkdf("SHA-3(512)", key_len, password, &[], &HashMap::new())?;
+    policy.check_pbkdf("SHA-3(512)", key_len, password, &[], &BTreeMap::new())?;
     crypto::digest("SHA-3(512)", password.as_bytes(), policy)
 }
 
@@ -92,7 +92,7 @@ fn pbkdf_timed(
     msec: u32,
     key_len: usize,
     policy: &Box<dyn CryptoPolicy>,
-) -> Result<(Vec<u8>, HashMap<String, usize>), &'static str> {
+) -> Result<(Vec<u8>, BTreeMap<String, usize>), &'static str> {
     crypto::derive_key_from_password_timed(
         botan_alg,
         botan_param_order,
@@ -109,7 +109,7 @@ fn pbkdf_manual(
     botan_param_order: &[&[&str; 3]; 2],
     password: &str,
     salt: &Vec<u8>,
-    params_map: HashMap<String, usize>,
+    params_map: BTreeMap<String, usize>,
     key_len: usize,
     policy: &Box<dyn CryptoPolicy>,
 ) -> Result<Vec<u8>, &'static str> {
@@ -143,9 +143,7 @@ pub fn from_phc_alg(alg: &str) -> (String, Option<String>) {
     return (alg.to_string(), None);
 }
 
-fn format_phc(alg: &str, params: &HashMap<String, usize>, salt: &Vec<u8>) -> String {
-    let mut params: Vec<_> = params.iter().collect();
-    params.sort_by(|a, b| a.0.cmp(b.0));
+fn format_phc(alg: &str, params: &BTreeMap<String, usize>, salt: &Vec<u8>) -> String {
     format!(
         "${}${}${}",
         alg,

--- a/src/prot.rs
+++ b/src/prot.rs
@@ -24,7 +24,7 @@
 extern crate phc;
 extern crate rpassword;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use consts;
 use crypto;
@@ -88,7 +88,7 @@ pub fn decrypt(
     if let Some(pbkdf) = pbkdf {
         let phc: phc::raw::RawPHC = pbkdf.parse().map_err(|_| "Failed to parse PHC")?;
         let (alg, pbkdf2_hash) = from_phc_alg(phc.id());
-        let mut params_map: HashMap<String, usize> = HashMap::new();
+        let mut params_map: BTreeMap<String, usize> = BTreeMap::new();
         params_map.extend(
             phc.params()
                 .iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,16 +23,6 @@
 
 extern crate botan;
 
-pub fn digest(alg: &str, data: &[u8]) -> Result<Vec<u8>, &'static str> {
-    let hash = botan::HashFunction::new(alg).map_err(|_| "Botan error")?;
-    hash.update(data).map_err(|_| "Botan error")?;
-    hash.finish().map_err(|_| "Botan error")
-}
-
-pub fn hexdigest(alg: &str, data: &[u8]) -> Result<String, &'static str> {
-    Ok(hex::encode(digest(alg, data)?))
-}
-
 pub fn base64_encode(data: &[u8]) -> Result<String, &'static str> {
     botan::base64_encode(data).map_err(|_| "Botan error")
 }

--- a/test-data/simple-encrypt-agent007-gcm.ept
+++ b/test-data/simple-encrypt-agent007-gcm.ept
@@ -1,0 +1,5 @@
+Regular text
+// <( ENCRYPTED Agent_007 cipher:aes-256-gcm$iv=AQIDBAUGBwgJEBES pbkdf:$argon2$m=16,p=1,t=1$AQIDBAUGBwg= )>
+// <( DATA ZVGRCSAZ5ZtRcirkastxwfbhc53y4dz8qaypsA== )>
+// <( END Agent_007 )>
+More regular text

--- a/tests/cli/cipher.rs
+++ b/tests/cli/cipher.rs
@@ -1,0 +1,173 @@
+extern crate assert_cmd;
+extern crate predicates;
+extern crate tempfile;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::fs;
+use std::process::Command;
+
+use Fixture;
+
+#[test]
+fn encrypt_gcm_random_iv() {
+    let epts = &[
+        Fixture::copy("sample/simple.ept"),
+        Fixture::copy("sample/simple.ept"),
+    ];
+
+    for ept in epts {
+        Command::cargo_bin("enprot")
+            .unwrap()
+            .arg("--encrypt")
+            .arg("Agent_007")
+            .arg("--pbkdf")
+            .arg("argon2")
+            .arg("--pbkdf-params")
+            .arg("t=1,p=1,m=16")
+            .arg("--pbkdf-salt")
+            .arg("0102030405060708")
+            .arg("-k")
+            .arg("Agent_007=password")
+            .arg("--cipher")
+            .arg("aes-256-gcm")
+            .arg(&ept.path)
+            .assert()
+            .success();
+        assert!(&fs::read_to_string(&ept.path)
+            .unwrap()
+            .contains("aes-256-gcm"));
+        let out = Fixture::blank("out.ept");
+        Command::cargo_bin("enprot")
+            .unwrap()
+            .arg("-d")
+            .arg("Agent_007")
+            .arg("-k")
+            .arg("Agent_007=password")
+            .arg(&ept.path)
+            .arg("-o")
+            .arg(&out.path)
+            .assert()
+            .success();
+        // make sure we can decrypt correctly
+        assert_eq!(
+            &fs::read_to_string(&out.path).unwrap(),
+            &fs::read_to_string(&ept.source).unwrap()
+        );
+    }
+    // should be random IVs so these should not match
+    assert_ne!(
+        &fs::read_to_string(&epts[0].path).unwrap(),
+        &fs::read_to_string(&epts[1].path).unwrap(),
+    );
+}
+
+#[test]
+fn encrypt_gcm() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("--pbkdf")
+        .arg("argon2")
+        .arg("--pbkdf-params")
+        .arg("t=1,p=1,m=16")
+        .arg("--pbkdf-salt")
+        .arg("0102030405060708")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg("--cipher-iv")
+        .arg("010203040506070809101112")
+        .arg(&ept.path)
+        .assert()
+        .success();
+    assert!(&fs::read_to_string(&ept.path)
+        .unwrap()
+        .contains("aes-256-gcm"));
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string("test-data/simple-encrypt-agent007-gcm.ept").unwrap()
+    );
+    // decrypt
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-d")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg(&ept.path)
+        .assert()
+        .success();
+    // make sure we can decrypt correctly
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&ept.source).unwrap(),
+    );
+}
+
+// IV should not be supplied for aes-256-siv
+#[test]
+fn encrypt_siv_iv() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("--pbkdf")
+        .arg("argon2")
+        .arg("--pbkdf-params")
+        .arg("t=1,p=1,m=16")
+        .arg("--pbkdf-salt")
+        .arg("0102030405060708")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--cipher")
+        .arg("aes-256-siv")
+        .arg("--cipher-iv")
+        .arg("010203040506070809101112")
+        .arg(&ept.path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("IV was supplied"));
+}
+
+#[test]
+fn encrypt_siv() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--cipher")
+        .arg("aes-256-siv")
+        .arg(&ept.path)
+        .assert()
+        .success();
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string("test-data/simple-encrypt-agent007.ept").unwrap(),
+    );
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("-d")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg(&ept.path)
+        .assert()
+        .success();
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&ept.source).unwrap(),
+    );
+}

--- a/tests/cli/encrypt_store.rs
+++ b/tests/cli/encrypt_store.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
 
+use hexdigest;
 use Fixture;
 
 #[test]
@@ -36,9 +37,9 @@ fn encrypt_store_agent007() {
         "7a8da017c0fe671ba16f4bc55b884444e708849290d8366f19c552c90950b8c2",
     ] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
-                &fs::read(casdir.path().join(hashval)).unwrap()
+                &fs::read(casdir.path().join(hashval)).unwrap(),
             )
             .unwrap(),
             hashval
@@ -85,9 +86,9 @@ fn encrypt_store_geheim() {
     );
     for hashval in vec!["ab664af9ef8ed0a7a542c4bcc0d2d2bf06973038d83ddbfcdd031eb80a308d5a"] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
-                &fs::read(casdir.path().join(hashval)).unwrap()
+                &fs::read(casdir.path().join(hashval)).unwrap(),
             )
             .unwrap(),
             hashval
@@ -137,7 +138,7 @@ fn encrypt_store_both_agent007_geheim() {
         "ab664af9ef8ed0a7a542c4bcc0d2d2bf06973038d83ddbfcdd031eb80a308d5a",
     ] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
                 &fs::read(casdir.path().join(hashval)).unwrap()
             )
@@ -189,7 +190,7 @@ fn encrypt_store_agent007_geheim() {
         "7a8da017c0fe671ba16f4bc55b884444e708849290d8366f19c552c90950b8c2",
     ] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
                 &fs::read(casdir.path().join(hashval)).unwrap()
             )
@@ -216,7 +217,7 @@ fn encrypt_store_agent007_geheim() {
     );
     for hashval in vec!["86117980a54565a74cc5195865827aab44cfafc138e723e3a409631384d74ee2"] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
                 &fs::read(casdir.path().join(hashval)).unwrap()
             )
@@ -277,7 +278,7 @@ fn encrypt_store_geheim_agent007() {
     );
     for hashval in vec!["ab664af9ef8ed0a7a542c4bcc0d2d2bf06973038d83ddbfcdd031eb80a308d5a"] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
                 &fs::read(casdir.path().join(hashval)).unwrap()
             )
@@ -304,7 +305,7 @@ fn encrypt_store_geheim_agent007() {
     );
     for hashval in vec!["7a8da017c0fe671ba16f4bc55b884444e708849290d8366f19c552c90950b8c2"] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
                 &fs::read(casdir.path().join(hashval)).unwrap()
             )
@@ -371,7 +372,7 @@ fn encrypt_store_agent007_argon2() {
         "b30ccd443bae74afc464822857fad6974f0cbb12197368494cc311441c74ea20",
     ] {
         assert_eq!(
-            enprot::utils::hexdigest(
+            hexdigest(
                 "SHA-3(256)",
                 &fs::read(casdir.path().join(hashval)).unwrap()
             )

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -1,3 +1,4 @@
+mod cipher;
 mod encrypt_decrypt;
 mod encrypt_store;
 mod misc;

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -4,4 +4,5 @@ mod encrypt_store;
 mod misc;
 mod pbkdf;
 mod pipe;
+mod policy;
 mod store_fetch;

--- a/tests/cli/policy.rs
+++ b/tests/cli/policy.rs
@@ -1,0 +1,166 @@
+extern crate assert_cmd;
+extern crate predicates;
+extern crate tempfile;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use Fixture;
+
+#[test]
+fn policy_nist_pbkdf() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    // legacy not allowed
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("legacy")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "PBKDF algorithm is not permitted by policy",
+        ));
+
+    // argon2 not allowed
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("argon2")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "PBKDF algorithm is not permitted by policy",
+        ));
+
+    // pbkdf2 is allowed
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("pbkdf2")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .success();
+}
+
+#[test]
+fn policy_nist_cipher() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    // aes-256-gcm is allowed
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("pbkdf2")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .success();
+
+    // aes-256-gcm requires an IV of 12 bytes
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("pbkdf2")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg("--cipher-iv")
+        .arg("01020304050607080910111213141516")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "IV length does not match NIST recommendations for this cipher",
+        ));
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("pbkdf2")
+        .arg("--cipher")
+        .arg("aes-256-gcm")
+        .arg("--cipher-iv")
+        .arg("010203040506070809101112")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .success();
+
+    // aes-256-siv is not allowed
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg("--pbkdf")
+        .arg("pbkdf2")
+        .arg("--cipher")
+        .arg("aes-256-siv")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "Cipher algorithm is not permitted by policy",
+        ));
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -39,3 +39,15 @@ impl Fixture {
         fixture
     }
 }
+
+pub fn digest(alg: &str, data: &[u8]) -> Result<Vec<u8>, &'static str> {
+    let policy: Box<dyn enprot::crypto::CryptoPolicy> =
+        Box::new(enprot::crypto::CryptoPolicyNone {});
+    enprot::crypto::digest(alg, data, &policy)
+}
+
+pub fn hexdigest(alg: &str, data: &[u8]) -> Result<String, &'static str> {
+    let policy: Box<dyn enprot::crypto::CryptoPolicy> =
+        Box::new(enprot::crypto::CryptoPolicyNone {});
+    enprot::crypto::hexdigest(alg, data, &policy)
+}


### PR DESCRIPTION
~~This was meant to be a draft PR as I have not added tests.~~
Ready for review.

Note that this is adding AES-GCM, not AES-GCM-SIV.

AES-GCM example:
```
$ enprot -e Agent_007 -k Agent_007=pass --cipher aes-256-gcm sample/simple.ept -o -
Regular text
// <( ENCRYPTED Agent_007 cipher:aes-256-gcm$iv=HWbJKztPywut/esK pbkdf:$argon2$m=61440,p=1,t=1$L/VnX7gKRU3nGefLc00Kgg== )>
// <( DATA 1ybFBnR4RmvFTkJAc7tquB/iJZkHlX3H6SlO3w== )>
// <( END Agent_007 )>
More regular text
```

Policy example:
```
$ enprot -e Agent_007 -k Agent_007=pass --policy nist sample/simple.ept -o -
PBKDF algorithm is not permitted by policy: Argon2id
Algorithm not permitted by policy in sample/simple.ept, aborting.
```
```
$ enprot -e Agent_007 -k Agent_007=pass --policy nist --pbkdf pbkdf2 sample/simple.ept -o -
Cipher algorithm is not permitted by policy: AES-256/SIV
Algorithm not permitted by policy in sample/simple.ept, aborting.
```
```
$ enprot -e Agent_007 -k Agent_007=pass --policy nist --pbkdf pbkdf2 --cipher aes-256-gcm sample/simple.ept -o -
Regular text
// <( ENCRYPTED Agent_007 cipher:aes-256-gcm$iv=b7QXisJ47PasHU/V pbkdf:$pbkdf2-sha256$i=100000$cO8/89BI2pFwHEQ2cE28lQ== )>
// <( DATA CID9GpkhQmab2CvjbYmmEwAOV1ps8dtuQSehCw== )>
// <( END Agent_007 )>
More regular text
```