### PR TITLE
Add fips flag

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn aes_256_gcm() {
-        let policy: Box<dyn crypto::CryptoPolicy> = Box::new(crypto::CryptoPolicyNone {});
+        let policy: Box<dyn crypto::CryptoPolicy> = Box::new(crypto::CryptoPolicyDefault {});
         let key: &[u8] =
             &hex::decode("feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308")
                 .unwrap();
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn aes_256_gcm_siv() {
-        let policy: Box<dyn crypto::CryptoPolicy> = Box::new(crypto::CryptoPolicyNone {});
+        let policy: Box<dyn crypto::CryptoPolicy> = Box::new(crypto::CryptoPolicyDefault {});
         let key: &[u8] =
             &hex::decode("0100000000000000000000000000000000000000000000000000000000000000")
                 .unwrap();

--- a/src/policy/default.rs
+++ b/src/policy/default.rs
@@ -21,21 +21,59 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub const VALID_CIPHER_ALGS: &[&str] = &["aes-256-siv", "aes-256-gcm", "aes-256-gcm-siv"];
+use std::collections::BTreeMap;
 
-// parsing separators
-pub const DEFAULT_LEFT_SEP: &str = "// <(";
-pub const DEFAULT_RIGHT_SEP: &str = ")>";
+use policy::CryptoPolicy;
 
-// valid value lists
-pub const VALID_PBKDF_ALGS: &[&str] = &[
-    "argon2",
-    "scrypt",
-    "pbkdf2-sha256",
-    "pbkdf2-sha512",
-    "legacy",
-];
+pub struct CryptoPolicyDefault {}
 
-// policies
-pub const VALID_POLICIES: &[&str] = &["default", "nist"];
-pub const DEFAULT_POLICY: &str = "default";
+impl CryptoPolicyDefault {
+    const DEFAULT_PBKDF_ALG: &'static str = "argon2";
+    const DEFAULT_PBKDF_SALT_LEN: usize = 16;
+    pub const DEFAULT_PBKDF_MSEC: u32 = 100;
+    const DEFAULT_CIPHER_ALG: &'static str = "aes-256-siv";
+}
+
+// allow everything
+impl CryptoPolicy for CryptoPolicyDefault {
+    fn check_hash(&self, _alg: &str) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn check_pbkdf(
+        &self,
+        _alg: &str,
+        _key_len: usize,
+        _password: &str,
+        _salt: &[u8],
+        _params: &BTreeMap<String, usize>,
+    ) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn check_cipher(
+        &self,
+        _alg: &str,
+        _key: &[u8],
+        _iv: &[u8],
+        _ad: &[u8],
+    ) -> Result<(), &'static str> {
+        Ok(())
+    }
+
+    fn default_pbkdf_alg(&self) -> String {
+        Self::DEFAULT_PBKDF_ALG.to_string()
+    }
+
+    fn default_pbkdf_salt_length(&self) -> usize {
+        Self::DEFAULT_PBKDF_SALT_LEN
+    }
+
+    fn default_pbkdf_millis(&self) -> u32 {
+        Self::DEFAULT_PBKDF_MSEC
+    }
+
+    fn default_cipher_alg(&self) -> String {
+        Self::DEFAULT_CIPHER_ALG.to_string()
+    }
+}

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -21,21 +21,28 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-pub const VALID_CIPHER_ALGS: &[&str] = &["aes-256-siv", "aes-256-gcm", "aes-256-gcm-siv"];
+use std::collections::BTreeMap;
 
-// parsing separators
-pub const DEFAULT_LEFT_SEP: &str = "// <(";
-pub const DEFAULT_RIGHT_SEP: &str = ")>";
+pub mod default;
+pub mod nist;
 
-// valid value lists
-pub const VALID_PBKDF_ALGS: &[&str] = &[
-    "argon2",
-    "scrypt",
-    "pbkdf2-sha256",
-    "pbkdf2-sha512",
-    "legacy",
-];
+pub trait CryptoPolicy {
+    fn check_hash(&self, alg: &str) -> Result<(), &'static str>;
 
-// policies
-pub const VALID_POLICIES: &[&str] = &["default", "nist"];
-pub const DEFAULT_POLICY: &str = "default";
+    fn check_pbkdf(
+        &self,
+        alg: &str,
+        key_len: usize,
+        password: &str,
+        salt: &[u8],
+        params: &BTreeMap<String, usize>,
+    ) -> Result<(), &'static str>;
+
+    fn check_cipher(&self, alg: &str, key: &[u8], iv: &[u8], ad: &[u8])
+        -> Result<(), &'static str>;
+
+    fn default_pbkdf_alg(&self) -> String;
+    fn default_pbkdf_salt_length(&self) -> usize;
+    fn default_pbkdf_millis(&self) -> u32;
+    fn default_cipher_alg(&self) -> String;
+}

--- a/src/policy/nist.rs
+++ b/src/policy/nist.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2019-2020 [Ribose Inc](https://www.ribose.com).
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use phf::phf_set;
+use std::collections::BTreeMap;
+
+use policy::default::CryptoPolicyDefault;
+use policy::CryptoPolicy;
+
+pub struct CryptoPolicyNIST {}
+
+impl CryptoPolicyNIST {
+    const DEFAULT_PBKDF_ALG: &'static str = "pbkdf2-sha512";
+    const DEFAULT_PBKDF_SALT_LEN: usize = 32;
+    // no policy per se, so copy the default policy setting
+    const DEFAULT_PBKDF_MSEC: u32 = CryptoPolicyDefault::DEFAULT_PBKDF_MSEC;
+    const DEFAULT_CIPHER_ALG: &'static str = "aes-256-gcm";
+    const NIST_APPROVED_PBKDFS: phf::Set<&'static str> = phf_set! {
+        "pbkdf2-sha256",
+        "pbkdf2-sha512",
+    };
+    const NIST_APPROVED_CIPHERS: phf::Set<&'static str> = phf_set! {
+        "aes-256-gcm",
+    };
+    const NIST_APPROVED_HASHES: phf::Set<&'static str> = phf_set! {
+        "sha3-256",
+        "sha3-512",
+    };
+    const NIST_PBKDF_MIN_SALT_LEN: usize = 16;
+
+    fn check_alg(&self, kind: &str, alg: &str) -> Result<(), &'static str> {
+        let lst = match kind {
+            "Cipher" => &Self::NIST_APPROVED_CIPHERS,
+            "Hash" => &Self::NIST_APPROVED_HASHES,
+            "PBKDF" => &Self::NIST_APPROVED_PBKDFS,
+            _ => return Err("Invalid algorithm kind"),
+        };
+        if lst.contains(alg) {
+            Ok(())
+        } else {
+            eprintln!("{} algorithm is not permitted by policy: {}", kind, alg);
+            Err("Algorithm not permitted by policy")
+        }
+    }
+}
+
+impl CryptoPolicy for CryptoPolicyNIST {
+    fn check_hash(&self, alg: &str) -> Result<(), &'static str> {
+        self.check_alg("Hash", alg)
+    }
+
+    fn check_pbkdf(
+        &self,
+        alg: &str,
+        key_len: usize,
+        _password: &str,
+        salt: &[u8],
+        params: &BTreeMap<String, usize>,
+    ) -> Result<(), &'static str> {
+        self.check_alg("PBKDF", alg)?;
+        if salt.len() < Self::NIST_PBKDF_MIN_SALT_LEN {
+            return Err("Salt length violates policy");
+        }
+        if key_len < 14 {
+            return Err("Key length violates policy");
+        }
+        if let Some(iters) = params.get("i") {
+            if *iters < 1000 {
+                return Err("Iteration count violates policy");
+            }
+        }
+        Ok(())
+    }
+
+    fn check_cipher(
+        &self,
+        alg: &str,
+        _key: &[u8],
+        iv: &[u8],
+        _ad: &[u8],
+    ) -> Result<(), &'static str> {
+        self.check_alg("Cipher", alg)?;
+        if alg == "aes-256-gcm" && iv.len() != 96 / 8 {
+            return Err("IV length does not match NIST recommendations for this cipher.");
+        }
+        Ok(())
+    }
+
+    fn default_pbkdf_alg(&self) -> String {
+        Self::DEFAULT_PBKDF_ALG.to_string()
+    }
+
+    fn default_pbkdf_salt_length(&self) -> usize {
+        Self::DEFAULT_PBKDF_SALT_LEN
+    }
+
+    fn default_pbkdf_millis(&self) -> u32 {
+        Self::DEFAULT_PBKDF_MSEC
+    }
+
+    fn default_cipher_alg(&self) -> String {
+        Self::DEFAULT_CIPHER_ALG.to_string()
+    }
+}

--- a/src/prot.rs
+++ b/src/prot.rs
@@ -157,9 +157,5 @@ pub fn decrypt(
         )?;
         key = thekey;
     }
-
-    match dec.process(&key, &iv, &[], &ct, policy) {
-        Ok(pt) => Ok(pt),
-        Err(_) => Err("Bad password?"),
-    }
+    Ok(dec.process(&key, &iv, &[], &ct, policy)?)
 }

--- a/tests/cli/policy.rs
+++ b/tests/cli/policy.rs
@@ -1,184 +1,243 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
+use std::fs;
 use std::process::Command;
 
 use Fixture;
 
-#[test]
-fn policy_nist_pbkdf() {
+fn test_policy_err(policy: &str, args: &[&str], err: &str) {
     let ept = Fixture::copy("sample/simple.ept");
-
-    // legacy not allowed
+    // not allowed
     Command::cargo_bin("enprot")
         .unwrap()
         .arg("--policy")
-        .arg("nist")
+        .arg(policy)
         .arg("-e")
         .arg("Agent_007")
         .arg("-k")
         .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("legacy")
-        .arg("--cipher")
-        .arg("aes-256-gcm")
         .arg(&ept.path)
         .arg("-o")
         .arg("-")
+        .args(args)
         .assert()
         .failure()
-        .stderr(predicates::str::contains(
-            "PBKDF algorithm is not permitted by policy",
-        ));
-
-    // argon2 not allowed
+        .stderr(predicates::str::contains(err));
+    // same for decryption
+    let out = Fixture::copy("sample/simple.ept");
     Command::cargo_bin("enprot")
         .unwrap()
-        .arg("--policy")
-        .arg("nist")
+        .arg("--defaults") // load the defaults, but don't enforce it
+        .arg(policy)
         .arg("-e")
         .arg("Agent_007")
         .arg("-k")
         .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("argon2")
-        .arg("--cipher")
-        .arg("aes-256-gcm")
         .arg(&ept.path)
         .arg("-o")
-        .arg("-")
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains(
-            "PBKDF algorithm is not permitted by policy",
-        ));
-
-    // pbkdf2 is allowed
-    Command::cargo_bin("enprot")
-        .unwrap()
-        .arg("--policy")
-        .arg("nist")
-        .arg("-e")
-        .arg("Agent_007")
-        .arg("-k")
-        .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("pbkdf2-sha256")
-        .arg("--cipher")
-        .arg("aes-256-gcm")
-        .arg(&ept.path)
-        .arg("-o")
-        .arg("-")
+        .arg(&out.path)
+        .args(args)
         .assert()
         .success();
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg(policy)
+        .arg("-d")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg(&out.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(err));
+}
+
+fn test_policy_ok(policy: &str, args: &[&str]) {
+    let ept = Fixture::copy("sample/simple.ept");
+    let out = Fixture::blank("out.ept");
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg(policy)
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .args(args)
+        .arg(&ept.path)
+        .arg("-o")
+        .arg(&out.path)
+        .assert()
+        .success();
+    assert_ne!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&out.path).unwrap()
+    );
+    // decryption
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg(policy)
+        .arg("-d")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg(&out.path)
+        .assert()
+        .success();
+    assert_eq!(
+        &fs::read_to_string(&ept.path).unwrap(),
+        &fs::read_to_string(&out.path).unwrap()
+    );
 }
 
 #[test]
-fn policy_nist_cipher() {
-    let ept = Fixture::copy("sample/simple.ept");
+fn nist_disallowed_pbkdfs() {
+    test_policy_err(
+        "nist",
+        &["--pbkdf", "legacy"],
+        "PBKDF algorithm is not permitted by policy",
+    );
+    test_policy_err(
+        "nist",
+        &["--pbkdf", "argon2"],
+        "PBKDF algorithm is not permitted by policy",
+    );
+}
 
-    // aes-256-gcm is allowed
-    Command::cargo_bin("enprot")
-        .unwrap()
-        .arg("--policy")
-        .arg("nist")
-        .arg("-e")
-        .arg("Agent_007")
-        .arg("-k")
-        .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("pbkdf2-sha256")
-        .arg("--cipher")
-        .arg("aes-256-gcm")
-        .arg(&ept.path)
-        .arg("-o")
-        .arg("-")
-        .assert()
-        .success();
+#[test]
+fn nist_allowed_pbkdfs() {
+    test_policy_ok("nist", &["--pbkdf", "pbkdf2-sha256"]);
+    test_policy_ok("nist", &["--pbkdf", "pbkdf2-sha512"]);
+}
 
-    // aes-256-gcm requires an IV of 12 bytes
-    Command::cargo_bin("enprot")
-        .unwrap()
-        .arg("--policy")
-        .arg("nist")
-        .arg("-e")
-        .arg("Agent_007")
-        .arg("-k")
-        .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("pbkdf2-sha256")
-        .arg("--cipher")
-        .arg("aes-256-gcm")
-        .arg("--cipher-iv")
-        .arg("01020304050607080910111213141516")
-        .arg(&ept.path)
-        .arg("-o")
-        .arg("-")
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains(
-            "IV length does not match NIST recommendations for this cipher",
-        ));
-    Command::cargo_bin("enprot")
-        .unwrap()
-        .arg("--policy")
-        .arg("nist")
-        .arg("-e")
-        .arg("Agent_007")
-        .arg("-k")
-        .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("pbkdf2-sha256")
-        .arg("--cipher")
-        .arg("aes-256-gcm")
-        .arg("--cipher-iv")
-        .arg("010203040506070809101112")
-        .arg(&ept.path)
-        .arg("-o")
-        .arg("-")
-        .assert()
-        .success();
+#[test]
+fn nist_pbkdf2_params() {
+    // pbkdf2 requires a minimum iteration count
+    test_policy_err(
+        "nist",
+        &["--pbkdf", "pbkdf2-sha256", "--pbkdf-params", "i=999"],
+        "Iteration count violates policy",
+    );
+    test_policy_err(
+        "nist",
+        &["--pbkdf", "pbkdf2-sha512", "--pbkdf-params", "i=999"],
+        "Iteration count violates policy",
+    );
+
+    test_policy_ok(
+        "nist",
+        &["--pbkdf", "pbkdf2-sha256", "--pbkdf-params", "i=1000"],
+    );
+    test_policy_ok(
+        "nist",
+        &["--pbkdf", "pbkdf2-sha512", "--pbkdf-params", "i=1000"],
+    );
+}
+
+#[test]
+fn nist_cipher() {
+    test_policy_ok("nist", &["--cipher", "aes-256-gcm"]);
+
+    test_policy_err(
+        "nist",
+        &[
+            "--cipher",
+            "aes-256-gcm",
+            "--cipher-iv",
+            "01020304050607080910111213141516",
+        ],
+        "IV length does not match NIST recommendations for this cipher",
+    );
+    test_policy_ok(
+        "nist",
+        &[
+            "--cipher",
+            "aes-256-gcm",
+            "--cipher-iv",
+            "010203040506070809101112",
+        ],
+    );
 
     // aes-256-siv is not allowed
-    Command::cargo_bin("enprot")
-        .unwrap()
-        .arg("--policy")
-        .arg("nist")
-        .arg("-e")
-        .arg("Agent_007")
-        .arg("-k")
-        .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("pbkdf2-sha256")
-        .arg("--cipher")
-        .arg("aes-256-siv")
-        .arg(&ept.path)
-        .arg("-o")
-        .arg("-")
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains(
-            "Cipher algorithm is not permitted by policy",
-        ));
+    test_policy_err(
+        "nist",
+        &["--cipher", "aes-256-siv"],
+        "Cipher algorithm is not permitted by policy",
+    );
 
     // aes-256-gcm-siv is not allowed
+    test_policy_err(
+        "nist",
+        &["--cipher", "aes-256-gcm-siv"],
+        "Cipher algorithm is not permitted by policy",
+    );
+}
+
+#[test]
+fn fips_flag() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    // ensure we select some sane defaults
     Command::cargo_bin("enprot")
         .unwrap()
-        .arg("--policy")
-        .arg("nist")
+        .arg("--fips")
         .arg("-e")
         .arg("Agent_007")
         .arg("-k")
         .arg("Agent_007=password")
-        .arg("--pbkdf")
-        .arg("pbkdf2-sha256")
-        .arg("--cipher")
-        .arg("aes-256-gcm-siv")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains("pbkdf:$pbkdf2-sha512$")
+                .and(predicates::str::contains("cipher:aes-256-gcm$iv=")),
+        );
+
+    // should not be able to set a conflicting policy
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--fips")
+        .arg("--policy")
+        .arg("default")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
         .arg(&ept.path)
         .arg("-o")
         .arg("-")
         .assert()
         .failure()
         .stderr(predicates::str::contains(
-            "Cipher algorithm is not permitted by policy",
+            "Policy setting of 'default' conflicts with --fips",
         ));
+}
+
+#[test]
+fn defaults_policy_conflict() {
+    let ept = Fixture::copy("sample/simple.ept");
+
+    // nist policy conflicts with default settings
+    Command::cargo_bin("enprot")
+        .unwrap()
+        .arg("--policy")
+        .arg("nist")
+        .arg("--defaults")
+        .arg("default")
+        .arg("-e")
+        .arg("Agent_007")
+        .arg("-k")
+        .arg("Agent_007=password")
+        .arg(&ept.path)
+        .arg("-o")
+        .arg("-")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("not permitted by policy"));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,12 +43,12 @@ impl Fixture {
 
 pub fn digest(alg: &str, data: &[u8]) -> Result<Vec<u8>, &'static str> {
     let policy: Box<dyn enprot::crypto::CryptoPolicy> =
-        Box::new(enprot::crypto::CryptoPolicyNone {});
+        Box::new(enprot::crypto::CryptoPolicyDefault {});
     enprot::crypto::digest(alg, data, &policy)
 }
 
 pub fn hexdigest(alg: &str, data: &[u8]) -> Result<String, &'static str> {
     let policy: Box<dyn enprot::crypto::CryptoPolicy> =
-        Box::new(enprot::crypto::CryptoPolicyNone {});
+        Box::new(enprot::crypto::CryptoPolicyDefault {});
     enprot::crypto::hexdigest(alg, data, &policy)
 }


### PR DESCRIPTION
This does a few things:

* Add the `--fips` flag. This is automatically forced if `/proc/sys/crypto/fips_enabled` is `1`.
* Move default settings into crypto policies.
* Move policies into separate mod.
* Make decryption errors more verbose.
* Add --defaults option.
* Make policy tests more thorough.
* **Breaking Change** Renamed "none" policy to "default". `enprot --policy none` -> `enprot --policy default`