### PR TITLE
ci: Publish to crates.io.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,22 @@ env:
   EXE_NAME: enprot
 
 jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check version
+        run: |
+          set -euxo pipefail
+          if [ "$(grep '^version' Cargo.toml | cut -d '"' -f2)" != "${GITHUB_REF#refs/tags/}" ]; then
+            echo "Version tag does not match manifest"
+            exit 1
+          fi
+
   release-archive:
+    needs: [checks]
     name: archive
     timeout-minutes: 15
     strategy:
@@ -155,4 +170,19 @@ jobs:
             ${{ github.repository }} \
             "$RELEASE_TAG" \
             ../archives/*
+
+  publish-crate:
+    name: crates.io
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euxo pipefail
+          ci/install.sh
+          RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          cargo publish
 

--- a/ci/build-static.ps1
+++ b/ci/build-static.ps1
@@ -7,10 +7,6 @@ $BOTAN_MODULES = "$($(get-content 'ci\botan-modules') -join ',')"
   $ErrorActionPreference = 'Continue'
   & cargo install --version "$Env:CROSS_VERSION" cross
 }
-# update version in manifest to match our tag
-(Get-Content Cargo.toml) |
-  %{ $_ -replace '^version.*',"version = `"$Env:RELEASE_TAG`"" } |
-  Set-Content .\Cargo.toml
 
 # build
 &{

--- a/ci/build-static.sh
+++ b/ci/build-static.sh
@@ -11,8 +11,6 @@ EOF
 
 # install cross
 cargo install --version "$CROSS_VERSION" cross
-# update version in manifest to match our tag
-sed -ie "s/^version.*/version = \"$RELEASE_TAG\"/" Cargo.toml
 # build
 cross -vv build --target "$TARGET" --release
 

--- a/docs/release-workflow.adoc
+++ b/docs/release-workflow.adoc
@@ -1,0 +1,12 @@
+= Enprot Release Workflow
+
+All development takes place on the `master` branch.
+
+To publish a new release, follow these steps:
+
+1. Update the version in `Cargo.toml`.
+2. Create a new release tag: `git tag -a 0.2.0 -m ''`
+3. Push the new tag: `git push origin 0.2.0`
+
+This will automatically publish a GitHub Release and publish the crate on crates.io.
+


### PR DESCRIPTION
I've only tested the dry-run of this, so it may or may not work correctly.
@ronaldtse Can you add the `CARGO_REGISTRY_TOKEN` for crates.io?