### PR TITLE
ci: Add snap package.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install snapcraft
         uses: samuelmeuli/action-snapcraft@v1
         with:
-          snapcraft_token: ${{ secrets.snapcraft_token }}
+          snapcraft_token: ${{ secrets.SNAPCRAFT_RELEASE_LOGIN }}
           use_lxd: true
       - name: Install review-tools
         run: sudo snap install review-tools

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,4 +190,25 @@ jobs:
         run: |
           cargo publish --no-verify
 
+  publish-snap:
+    name: snap
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+        with:
+          snapcraft_token: ${{ secrets.snapcraft_token }}
+          use_lxd: true
+      - name: Install review-tools
+        run: sudo snap install review-tools
+      - name: Build
+        run: |
+          RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+          sed -i "s/RELEASE_TAG/${RELEASE_TAG}/g" snap/snapcraft.yaml
+          sg lxd -c 'snapcraft --use-lxd'
+      - name: Publish
+        run: |
+          snapcraft upload *.snap --release stable
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: enprot
+base: core20
+version: 'RELEASE_TAG'
+summary: Enprot is a confidentiality processor for text and source code files.
+license: 'BSD-2-Clause'
+description: |
+  Engyon Protected Text (EPT) is a human-editable annotation method that
+  allows a text format document to contain finely grained cryptographic
+  confidentiality and integrity features.
+
+grade: stable
+confinement: strict
+
+parts:
+  enprot:
+    plugin: rust
+    source: .
+    build-packages:
+      - build-essential
+      - libbotan-2-dev
+    stage-packages:
+      - botan
+
+apps:
+  enprot:
+    command: bin/enprot
+


### PR DESCRIPTION
This adds a snap build to CI for tagged builds.

This requires two things:

1) We'll need to transfer ownership of [the snap](https://snapcraft.io/enprot) to a ribose account. I think I can request this transfer if given an account name.
2) We'll need a `snapcraft_token` secret with the contents of `snapcraft export-login --snaps enprot --channels stable -`.

Fixes #33 